### PR TITLE
Add CA certificate processing.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -66,7 +66,7 @@ func SetupClientConfig(cmd *cobra.Command, args []string) error {
 		Version:           Properties.APIVersion,
 		Insecure:          Flags.Global.Insecure,
 		Host:              Properties.APIHost,
-		UserAgent:         UserAgent + "/1.0 (" + Properties.CLIVersion + ") "  + runtime.GOOS + " " + runtime.GOARCH,
+		UserAgent:         UserAgent + "/1.0 (" + Properties.CLIVersion + ") " + runtime.GOOS + " " + runtime.GOARCH,
 		AdditionalHeaders: AdditionalHeaders,
 	}
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -59,13 +59,14 @@ func SetupClientConfig(cmd *cobra.Command, args []string) error {
 	clientConfig := &whisk.Config{
 		Cert:              Properties.Cert,
 		Key:               Properties.Key,
+		CaCert:            Properties.CaCert,
 		AuthToken:         Properties.Auth,
 		Namespace:         Properties.Namespace,
 		BaseURL:           baseURL,
 		Version:           Properties.APIVersion,
 		Insecure:          Flags.Global.Insecure,
 		Host:              Properties.APIHost,
-		UserAgent:         UserAgent + "/1.0 (" + Properties.CLIVersion + ") " + runtime.GOOS + " " + runtime.GOARCH,
+		UserAgent:         UserAgent + "/1.0 (" + Properties.CLIVersion + ") "  + runtime.GOOS + " " + runtime.GOARCH,
 		AdditionalHeaders: AdditionalHeaders,
 	}
 

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -46,6 +46,7 @@ type FlagsStruct struct {
 		Debug      bool
 		Cert       string
 		Key        string
+		CaCert     string
 		Auth       string
 		Apihost    string
 		Apiversion string
@@ -72,6 +73,7 @@ type FlagsStruct struct {
 	property struct {
 		cert          bool
 		key           bool
+		cacert        bool
 		auth          bool
 		apihost       bool
 		apiversion    bool

--- a/commands/wsk.go
+++ b/commands/wsk.go
@@ -63,6 +63,7 @@ func init() {
 	WskCmd.PersistentFlags().BoolVarP(&Flags.Global.Debug, "debug", "d", false, wski18n.T("debug level output"))
 	WskCmd.PersistentFlags().StringVar(&Flags.Global.Cert, "cert", "", wski18n.T("client cert"))
 	WskCmd.PersistentFlags().StringVar(&Flags.Global.Key, "key", "", wski18n.T("client key"))
+	WskCmd.PersistentFlags().StringVar(&Flags.Global.CaCert, "cacert", "", wski18n.T("CA certificate"))
 	WskCmd.PersistentFlags().StringVarP(&Flags.Global.Auth, "auth", "u", "", wski18n.T("authorization `KEY`"))
 	WskCmd.PersistentFlags().StringVar(&Flags.Global.Apihost, "apihost", "", wski18n.T("whisk API `HOST`"))
 	WskCmd.PersistentFlags().StringVar(&Flags.Global.Apiversion, "apiversion", "", wski18n.T("whisk API `VERSION`"))

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -337,12 +337,12 @@
     "translation": "get property"
   },
   {
-    "id": "client cert",
-    "translation": "client cert"
+    "id": "Client certificate filename",
+    "translation": "Client certificate filename"
   },
   {
-    "id": "client key",
-    "translation": "client key"
+    "id": "Client key filename",
+    "translation": "Client key filename"
   },
   {
     "id": "whisk auth",
@@ -1586,5 +1586,13 @@
   {
     "id": "A response type of 'http' is required when using path parameters.",
     "translation": "A response type of 'http' is required when using path parameters."
+  },
+  {
+    "id": "{{.ok}} CA cert set. Run 'wsk property get --cacert' to see the new value.\n",
+    "translation": "{{.ok}} CA cert set. Run 'wsk property get --cacert' to see the new value.\n"
+  },
+  {
+    "id": "CA certificate filename",
+    "translation": "CA certificate filename"
   }
 ]


### PR DESCRIPTION
Create a '--cacert' flag that allows wsk to honor self-signing CAs if the certificate is provided. While not eliminating the need for wsk -i this does provide a more secure alternative for environments where the signing authority is stable, not needed in the system setup, and not easily changed (e.g. Kubernetes cluster development/integration installs).

https://github.com/apache/incubator-openwhisk-client-go/pull/109 should be committed prior to this CR.

I have an Apache CLA on file.