### PR TITLE
corrected description of go build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Then download the source code of the OpenWhisk CLI and the dependencies by
 typing:
 
 ```
-$ cd $GOPATH
-$ go get github.com/apache/incubator-openwhisk-cli
+$ mkdir -p $GOPATH/github.com/apache
+$ cd $GOPATH/github.com/apache
+$ git clone https://github.com/apache/incubator-openwhisk-cli
 $ cd $GOPATH/src/github.com/apache/incubator-openwhisk-cli
 ```
 


### PR DESCRIPTION
If you start off a clean GOPATH tree, it'll fail at `go get https://github.com/apache/incubator-openwhisk-cli` as prereqs are missing that are installed later. Need to run a `git clone` instead.