### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 #
 
 language: go
-jdk: openjdk8
 
 matrix:
   include:
@@ -25,6 +24,7 @@ matrix:
       group: deprecated-2017Q3
       go: "1.9.3"
       services: docker
+      jdk: openjdk8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,13 @@ matrix:
   include:
     - os: linux
       sudo: required
-      group: deprecated-2017Q3
       go: "1.9.3"
       services: docker
-      jdk: openjdk8
+      dist: xenial
 
 env:
   global:
-    - secure: "Br0fD9CAKm8gqyEuwmltNJd4dGJCxPpj6feugHlO+CFFwfE/+kJKkpTlsDuRfrUzUDlWiETNPf0XGSjvPFqZExnLCE9XQh2+XF6u+S3YBWfM+rbbyRVAK6BlTwmt0u3jRJ2JP7spedTGZA+qfIWI+UkwoOexo7NcqtMPLahiZzheaaad8y3J+crHQCrB/kPrhLqKVMEOkIbveFdfV2QLfCOWgqP8e1LGZhPZ2N4QcNo0iB5uI4ZyYszTZDniXFKxz7kBs4tl4ZQDqRHqL02qKPsjbvjrZp83ql+PbC2dpgXi9YpaDuBEqKKX1rTQP5ppcwbobot5U3ItHWzpXbLCdsWxvbde/0enjMmOF1wwl71hPYIf7PkQmNAWXRtL2Z1TguO/dKCeXBLDER4YDQ79GYpikAMqnrRLou4rsyZrNUzg8aHbELzAHppDSpqEJN8ymGgWgmWBT8yPaWVwN5CjPFOxLPrVEObcwcNSGOcOvtmUGCnXKSZminNZUjz5QfWqpA+LYCUIbeOI2X2D+iQWklWONaU2A+PcNLaaegwwj4K+9ZlU08Ed8Ud5ZGhjN9s72OtoFPdSHAyBgf/qxIdnTzmmE+SQ90mDtG3VqjHy28Ix7cIGqaIEC8shFb0kKHqQ7AVkLPm0bsh2fbbYu/5YVpXHfxlKWfOLBV14bHUq3v0="
+    - secure: "Br0fD9CAKm8gqyEuwmltNJd4dGJCxPpj6feugHlO+CFFwfE/+kJKkpTlsDuRfrUzUDlWiETNPf0XGSjvPFqZExnLCE9XQh2+XF6u+S3YBWfM+rbbyRVAK6BlTwmt0u3jRJ2JP7spedTGZA+qfIWI+UkwoOexo7NcqtMPLahiZzheaaad8y3J+crHQCrB/kPrhLqKVMEOkIbveFdfV2QLfCOWgqP8e1LGZhPZ2N4QcNo0iB5uI4ZyYszTZDniXFKxz7kBs4tl4ZQDqRHqL02qKPsjbvjrZp83ql+PbC2dpgXi9YpaDuBEqKKX1rTQP5ppcwbobot5U3ItHWzpXbLCdsWxvbde/0enjMmOF1wwl71hPYIf7PkQmNAWXRtL2Z1TguO/dKCeXBLDER4YDQ79GYpikAMqnrRLou4rsyZrNUzg8aHbELzAHppDSpqEJN8ymGgWgmWBT8yPaWVwN5CjPFOxLPrVEObcwcNSGOcOvtmUGCnXKSZminNZUjz5QfWqpA+LYCUIbeOI2X2D+iQWklWONaU2A+PcNLaaegwwj4K+9ZlU08Ed8Ud5ZGhjN9s72OtoFPdSHAyBgf/qxIdnTzmmE+SQ90mDtG3VqjHy28Ix7WskWebActionsTestscIGqaIEC8shFb0kKHqQ7AVkLPm0bsh2fbbYu/5YVpXHfxlKWfOLBV14bHUq3v0="
     - build_file_name=wsk
     # WARNING: if zip_file_name includes spaces or leading hyphen(s), it will create cosmetic breakage in 'before_deploy'
     - zip_file_name=OpenWhisk_CLI

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@
 #
 
 language: go
+jdk: openjdk8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 
 install:
   - cd $TRAVIS_BUILD_DIR/..
-  - pip install --upgrade pip setuptools
+  - pip install --user --upgrade pip setuptools
 
 before_script:
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       go: "1.9.3"
       services: docker
       dist: xenial
+      jdk: openjdk8
 
 env:
   global:

--- a/tests/src/test/scala/system/basic/WskCliBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskCliBasicTests.scala
@@ -874,7 +874,7 @@ class WskCliBasicTests extends TestHelpers with WskTestHelpers {
   behavior of "Wsk Namespace CLI"
 
   def WskNsCLI_RetListOneNs_test(wsk: Wsk, wp: WskProps): Unit = {
-    val lines = wsk.namespace.list()(wp).stdout.lines.toSeq
+    val lines = wsk.namespace.list()(wp).stdout.linesIterator.toSeq
     lines should have size 2
     lines.head shouldBe "namespaces"
     lines(1).trim should not be empty


### PR DESCRIPTION
`setuptools` install was failing due to package update error in `pip install step`

```
$ pip install --upgrade pip setuptools

/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.

  warnings.warn(warning, RequestsDependencyWarning)

DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support

Collecting pip

  Downloading https://files.pythonhosted.org/packages/30/db/9e38760b32e3e7f40cce46dd5fb107b8c73840df38f0046d8e6514e675a1/pip-19.2.3-py2.py3-none-any.whl (1.4MB)

Collecting setuptools

  Downloading https://files.pythonhosted.org/packages/6a/9a/50fadfd53ec909e4399b67c74cc7f4e883488035cfcdb90b685758fa8b34/setuptools-41.4.0-py2.py3-none-any.whl (580kB)

Installing collected packages: pip, setuptools

  Found existing installation: pip 19.2.1

    Uninstalling pip-19.2.1:

ERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/usr/local/bin/pip'
Consider using the `--user` option or check the permissions.
WARNING: You are using pip version 19.2.1, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command "pip install --upgrade pip setuptools" failed and exited with 1 during 
```

Similar to apache/openwhisk#4683 fix here was to to `--user` option with pip command