### PR TITLE
Ensure that the pollSince is greater than Activation start time

### DIFF
--- a/commands/activation.go
+++ b/commands/activation.go
@@ -402,7 +402,7 @@ var activationPollCmd = &cobra.Command{
 					reported[activation.ActivationID] = true
 				}
 				if activation.Start > pollSince {
-					pollSince = activation.Start
+					pollSince = activation.Start + 1
 				}
 			}
 			time.Sleep(time.Second * 2)


### PR DESCRIPTION
Ensure that the pollSince is greater than Activation start time. This ensures that poll command does not repeatedly keep on fetching the last activation

Fixes #459