### PR TITLE
convert secretValue int64 to string type

### DIFF
--- a/commands/action.go
+++ b/commands/action.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -873,7 +874,11 @@ func updateWebSecureAnnotation(websecure string, annotations whisk.KeyValueArr) 
 	} else {
 		whisk.Debug(whisk.DbgInfo, "Setting %v annotation; prior secret %v new secret %v\n",
 			WEB_SECURE_ANNOT, reflect.TypeOf(existingSecret), reflect.TypeOf(secureSecret))
-		annotations = annotations.AddOrReplace(&whisk.KeyValue{Key: WEB_SECURE_ANNOT, Value: secureSecret})
+		if newSecretIsInt {
+			annotations = annotations.AddOrReplace(&whisk.KeyValue{Key: WEB_SECURE_ANNOT, Value: strconv.FormatInt(secureSecret.(int64), 10)})
+		} else {
+			annotations = annotations.AddOrReplace(&whisk.KeyValue{Key: WEB_SECURE_ANNOT, Value: secureSecret})
+		}
 	}
 
 	return annotations


### PR DESCRIPTION
Manual test included all the possible value combination of --web-secure and --annotation flags. The following scenarios of combination were tested: 

1. --web-secure true -a require-whisk-auth: integer
2. --web-secure true -a require-whisk-auth: string 
3. --web-secure false -a require-whisk-auth: integer 
4. --web-secure false -a require-whisk-auth: string
5. --web-secure true
6. --web-secure false
7. -a require-whisk-auth integer
8. -a require-whisk-auth string

close https://github.ibm.com/BlueMix-Fabric/bluemix-openwhisk-cli/issues/329