### PR TITLE
remove test for download of iOS SDK

### DIFF
--- a/tests/src/test/scala/system/basic/WskSdkTests.scala
+++ b/tests/src/test/scala/system/basic/WskSdkTests.scala
@@ -83,21 +83,6 @@ class WskSdkTests extends TestHelpers with WskTestHelpers {
     }
   }
 
-  it should "download iOS sdk" in {
-    val dir = File.createTempFile("wskinstall", ".tmp")
-    dir.delete()
-    dir.mkdir() should be(true)
-
-    wsk.cli(wskprops.overrides ++ Seq("sdk", "install", "iOS"), workingDir = dir).stdout should include(
-      "Downloaded OpenWhisk iOS starter app. Unzip 'OpenWhiskIOSStarterApp.zip' and open the project in Xcode.")
-
-    val sdk = new File(dir, "OpenWhiskIOSStarterApp.zip")
-    sdk.exists() should be(true)
-    sdk.isFile() should be(true)
-    FileUtils.sizeOf(sdk) should be > 20000L
-    FileUtils.deleteDirectory(dir)
-  }
-
   it should "install the bash auto-completion bash script" in {
     // Use a temp dir for testing to not disturb user's local folder
     val dir = File.createTempFile("wskinstall", ".tmp")


### PR DESCRIPTION
core PR 4795 removed the iOS SDK download route from nginx.conf;
remove cli test that checks that route is available.

Minimal PR to repair build.  Probably should remove the iOS SDK support from the cli `install` command and the partial implementation from whisk-client-go/sdk.go