### PR TITLE
Support passing del annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,11 +53,11 @@ dependencies {
         build(['name':'github.com/mitchellh/go-homedir', 'version':'1111e456ffea841564ac0fa5f69c26ef44dafec9', 'transitive':false])
         build(['name':'github.com/nicksnyder/go-i18n/i18n/...', 'version':'991e81cc94f6c54209edb3192cb98e3995ad71c1', 'transitive':false])
         build(['name':'github.com/spf13/cobra', 'version':'1238ba19d24b0b9ceee2094e1cb31947d45c3e86', 'transitive':false])
-        build(['name':'github.com/spf13/pflag', 'version':'367864438f1b1a3c7db4da06a2f55b144e6784e0', 'transitive':false])
+        build(['name':'github.com/spf13/pflag', 'version':'81378bbcd8a1005f72b1e8d7579e5dd7b2d612ab', 'transitive':false])
         build(['name':'golang.org/x/sys/unix', 'version':'7f918dd405547ecb864d14a8ecbbfe205b5f930f', 'transitive':false])
         build(['name':'gopkg.in/yaml.v2', 'version':'eb3733d160e74a9c7e442f435eb3bea458e1d19f', 'transitive':false])
         build(['name':'github.com/ghodss/yaml', 'version':'0ca9ea5df5451ffdf184b4428c902747c2c11cd7', 'transitive':false])
-        build(['name':'github.com/apache/openwhisk-client-go/whisk','version':'d8ccb1442651beee6a9245913e3ca0cb182888b1','transitive':false])
+        build(['name':'github.com/apache/openwhisk-client-go/whisk','version':'44551f1f3b715e87c0319b55762d50c71d214460','transitive':false])
         build(['name':'github.com/apache/openwhisk-wskdeploy','version':'cbe7c52d99c1ead5172946d3aeb33adb5d5c40b2','transitive':false])
         // END - Imported from Godeps
         test name:'github.com/stretchr/testify', version:'b91bfb9ebec76498946beb6af7c0230c7cc7ba6c', transitive:false //, tag: 'v1.2.0'

--- a/commands/action.go
+++ b/commands/action.go
@@ -480,6 +480,9 @@ func parseAction(cmd *cobra.Command, args []string, update bool) (*whisk.Action,
 		return nil, noArtifactError()
 	}
 
+	if update {
+		action.DelAnnotations = Flags.action.delAnnotation
+	}
 	whisk.Debug(whisk.DbgInfo, "Parsed action struct: %#v\n", action)
 	return action, err
 }
@@ -1305,6 +1308,7 @@ func init() {
 	actionUpdateCmd.Flags().StringVarP(&Flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 	actionUpdateCmd.Flags().StringVar(&Flags.action.web, WEB_FLAG, "", wski18n.T("treat ACTION as a web action, a raw HTTP web action, or as a standard action; yes | true = web action, raw = raw HTTP web action, no | false = standard action"))
 	actionUpdateCmd.Flags().StringVar(&Flags.action.websecure, WEB_SECURE_FLAG, "", wski18n.T("secure the web action. where `SECRET` is true, false, or any string. Only valid when the ACTION is a web action"))
+	actionUpdateCmd.Flags().StringArrayVar(&Flags.action.delAnnotation, "del-annotation", []string{}, wski18n.T("del annotation"))
 
 	actionInvokeCmd.Flags().StringSliceVarP(&Flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
 	actionInvokeCmd.Flags().StringVarP(&Flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))

--- a/commands/action.go
+++ b/commands/action.go
@@ -576,6 +576,13 @@ func augmentWebSecureArg(cmd *cobra.Command, args []string, originalAction *whis
 				augmentedAction.Annotations = augmentedAction.Annotations.AppendKeyValueArr(getWebSecureAnnotations(existingAction))
 			}
 		}
+		// when "--web-secure false", need to delete require-whisk-auth annotation
+		secureSecret := webSecureSecret(Flags.action.websecure) // will be false when "--web-secure false"
+		existingSecret := augmentedAction.Annotations.GetValue(WEB_SECURE_ANNOT)
+		_, disableSecurity := secureSecret.(bool)
+		if existingSecret != nil && disableSecurity {
+			augmentedAction.DelAnnotations = []string{"require-whisk-auth"}
+		}
 		augmentedAction.Annotations = updateWebSecureAnnotation(Flags.action.websecure, augmentedAction.Annotations)
 	}
 

--- a/commands/action.go
+++ b/commands/action.go
@@ -1308,7 +1308,7 @@ func init() {
 	actionUpdateCmd.Flags().StringVarP(&Flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))
 	actionUpdateCmd.Flags().StringVar(&Flags.action.web, WEB_FLAG, "", wski18n.T("treat ACTION as a web action, a raw HTTP web action, or as a standard action; yes | true = web action, raw = raw HTTP web action, no | false = standard action"))
 	actionUpdateCmd.Flags().StringVar(&Flags.action.websecure, WEB_SECURE_FLAG, "", wski18n.T("secure the web action. where `SECRET` is true, false, or any string. Only valid when the ACTION is a web action"))
-	actionUpdateCmd.Flags().StringArrayVar(&Flags.action.delAnnotation, "del-annotation", []string{}, wski18n.T("del annotation"))
+	actionUpdateCmd.Flags().StringArrayVar(&Flags.action.delAnnotation, "del-annotation", []string{}, wski18n.T("the list of annotations to be deleted from the action, e.g. --del-annotation key1 --del-annotation key2"))
 
 	actionInvokeCmd.Flags().StringSliceVarP(&Flags.common.param, "param", "p", []string{}, wski18n.T("parameter values in `KEY VALUE` format"))
 	actionInvokeCmd.Flags().StringVarP(&Flags.common.paramFile, "param-file", "P", "", wski18n.T("`FILE` containing parameter values in JSON format"))

--- a/commands/flags.go
+++ b/commands/flags.go
@@ -136,22 +136,23 @@ type FlagsStruct struct {
 }
 
 type ActionFlags struct {
-	docker      string
-	native      bool
-	copy        bool
-	web         string
-	websecure   string
-	sequence    bool
-	timeout     int
-	memory      int
-	logsize     int
-	concurrency int
-	result      bool
-	kind        string
-	main        string
-	url         bool
-	save        bool
-	saveAs      string
+	docker        string
+	native        bool
+	copy          bool
+	web           string
+	websecure     string
+	sequence      bool
+	timeout       int
+	memory        int
+	logsize       int
+	concurrency   int
+	result        bool
+	kind          string
+	main          string
+	url           bool
+	save          bool
+	saveAs        string
+	delAnnotation []string
 }
 
 func IsVerbose() bool {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskCliBasicUsageTests.scala
@@ -669,7 +669,7 @@ class WskCliBasicUsageTests extends TestHelpers with WskTestHelpers {
         Parameters(createKey, createValue) ++
         Parameters(origKey, origValue)
     }
-    val updateAnnotations = baseAnnotations ++ Parameters(updateKey, updateValue) ++ Parameters(
+    val updateAnnotations = createAnnotations ++ Parameters(updateKey, updateValue) ++ Parameters(
       origKey,
       overwrittenValue)
 

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -1416,6 +1416,10 @@
     "translation": "secure the web action. where `SECRET` is true, false, or any string. Only valid when the ACTION is a web action"
   },
   {
+    "id": "the list of annotations to be deleted from the action, e.g. --del-annotation key1 --del-annotation key2",
+    "translation": "the list of annotations to be deleted from the action, e.g. --del-annotation key1 --del-annotation key2"
+  },
+  {
     "id": "The --web-secure option is only valid when the --web option is enabled.",
     "translation": "The --web-secure option is only valid when the --web option is enabled."
   },


### PR DESCRIPTION
Currently, if passing another annotations, original previous annotation
will be removed and the passed new annotations will be added.

It may give users some confused that why my previous annotation gone.
So it is better to not delete user's previous annotation when adding new
annotation, but at the same time, need to provide a feature that
support to delete annotation by user via ClI, e.g.
```shell
wsk action update hello --del-annotation key1 --del-annotation key2
```


another brother prs to support del annotation: 
* https://github.com/apache/openwhisk-client-go/pull/137
* https://github.com/apache/openwhisk/pull/4940