### PR TITLE
Support array result

### DIFF
--- a/commands/action.go
+++ b/commands/action.go
@@ -199,7 +199,7 @@ func invokeAction(
 	qualifiedName QualifiedName,
 	parameters interface{},
 	blocking bool,
-	result bool) (map[string]interface{}, error) {
+	result bool) (interface{}, error) {
 	// TODO remove all global modifiers
 	Client.Namespace = qualifiedName.GetNamespace()
 	res, _, err := Client.Actions.Invoke(
@@ -214,7 +214,7 @@ func printInvocationResponse(
 	qualifiedName QualifiedName,
 	blocking bool,
 	header bool,
-	result map[string]interface{},
+	result interface{},
 	err error) error {
 	if err == nil {
 		printInvocationMsg(qualifiedName, blocking, header, result, color.Output)
@@ -232,13 +232,13 @@ func printInvocationResponse(
 func printFailedBlockingInvocationResponse(
 	qualifiedName QualifiedName,
 	header bool,
-	result map[string]interface{},
+	result interface{},
 	err error) error {
 	if isBlockingTimeout(err) {
 		printBlockingTimeoutMsg(
 			qualifiedName.GetNamespace(),
 			qualifiedName.GetEntityName(),
-			getValueFromJSONResponse(ACTIVATION_ID, result))
+			getValueFromResponse(ACTIVATION_ID, result))
 		return err
 	} else if isApplicationError(err) {
 		printInvocationMsg(
@@ -1169,7 +1169,7 @@ func printInvocationMsg(
 	qualifiedName QualifiedName,
 	blocking bool,
 	header bool,
-	response map[string]interface{},
+	response interface{},
 	outputStream io.Writer) {
 	if header {
 		fmt.Fprintf(
@@ -1180,7 +1180,7 @@ func printInvocationMsg(
 					"ok":        color.GreenString("ok:"),
 					"namespace": boldString(qualifiedName.GetNamespace()),
 					"name":      boldString(qualifiedName.GetEntityName()),
-					"id":        boldString(getValueFromJSONResponse(ACTIVATION_ID, response)),
+					"id":        boldString(getValueFromResponse(ACTIVATION_ID, response)),
 				}))
 	}
 

--- a/commands/util.go
+++ b/commands/util.go
@@ -604,16 +604,20 @@ func getChildValueStrings(keyValueArr whisk.KeyValueArr, key string, childKey st
 	return res
 }
 
-func getValueFromJSONResponse(field string, response map[string]interface{}) interface{} {
+func getValueFromResponse(field string, response interface{}) interface{} {
 	var res interface{}
 
-	for key, value := range response {
-		if key == field {
-			res = value
-			break
+	if result, ok := response.(map[string]interface{}); ok {
+		for key, value := range result {
+			if key == field {
+				res = value
+				break
+			}
 		}
 	}
-
+	if result, ok := response.([]interface{}); ok {
+		res = result
+	}
 	return res
 }
 

--- a/commands/util.go
+++ b/commands/util.go
@@ -617,6 +617,8 @@ func getValueFromResponse(field string, response interface{}) interface{} {
 	}
 	if result, ok := response.([]interface{}); ok {
 		res = result
+	} else {
+		res = ""
 	}
 	return res
 }

--- a/commands/util.go
+++ b/commands/util.go
@@ -605,22 +605,18 @@ func getChildValueStrings(keyValueArr whisk.KeyValueArr, key string, childKey st
 }
 
 func getValueFromResponse(field string, response interface{}) interface{} {
-	var res interface{}
-
 	if result, ok := response.(map[string]interface{}); ok {
 		for key, value := range result {
 			if key == field {
-				res = value
-				break
+				return value
 			}
 		}
 	}
 	if result, ok := response.([]interface{}); ok {
-		res = result
+		return result
 	} else {
-		res = ""
+		return ""
 	}
-	return res
 }
 
 func logoText() string {


### PR DESCRIPTION
- [x] Support array result

Another brother prs:
https://github.com/apache/openwhisk-client-go/pull/153 (should be merged secondly)
https://github.com/apache/openwhisk-wskdeploy/pull/1153  (should be merged firslty)

This pr can be merged thirdly

After merged this three prs and if openwhisk itself support `support array result`:
- invoker supports array result: https://github.com/apache/openwhisk/pull/5290 (merged)
- runtime images should support array result as well
  - go: https://github.com/apache/openwhisk-runtime-go/pull/170
  - java:
  - ...

use wsk can get the correct arrary result. e.g
### invoke action
* Current is
![image](https://user-images.githubusercontent.com/11749867/169981017-78fddc8d-58e5-4bc1-b9f3-db3037c365be.png)
* To-Be after the three prs merged
![image](https://user-images.githubusercontent.com/11749867/169981141-692d0c4c-d1c3-46c4-9cbb-f16c323404e3.png)
### activation get
* Currrent is
![image](https://user-images.githubusercontent.com/11749867/169981271-af6ff017-ce2a-4eb2-b34a-d99728f903db.png)
* To-Be after the three prs merged
![image](https://user-images.githubusercontent.com/11749867/169981427-e8608927-8729-4a7a-aaa4-649160674789.png)

